### PR TITLE
Make the Connect Timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ import (
 	"os"
 )
 
-endpoint := winrm.NewEndpoint(host, 5986, false, false, nil, nil, nil, 0)
+endpoint := winrm.NewEndpoint(host, 5986, false, false, nil, nil, nil, 0, 0)
 client, err := winrm.NewClient(endpoint, "Administrator", "secret")
 if err != nil {
 	panic(err)
@@ -92,7 +92,7 @@ import (
   "os"
 )
 
-endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0, 0)
 client, err := winrm.NewClient(endpoint,"Administrator", "secret")
 if err != nil {
 	panic(err)
@@ -115,7 +115,7 @@ import (
   "os"
 )
 
-endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0, 0)
 
 params := DefaultParameters
 params.TransportDecorator = func() Transporter { return &ClientNTLM{} }
@@ -145,7 +145,7 @@ import (
 )
 
 stdin := bytes.NewBufferString("ipconfig /all")
-endpoint := winrm.NewEndpoint("localhost", 5985, false, false,nil, nil, nil, 0)
+endpoint := winrm.NewEndpoint("localhost", 5985, false, false,nil, nil, nil, 0, 0)
 client , err := winrm.NewClient(endpoint, "Administrator", "secret")
 if err != nil {
 	panic(err)
@@ -193,7 +193,7 @@ For using HTTPS authentication with x 509 cert without checking the CA
 		return &winrm.ClientAuthRequest{}
 	}
 
-	endpoint := winrm.NewEndpoint(host, 5986, false, false, clientCert, clientKey, nil, 0)
+	endpoint := winrm.NewEndpoint(host, 5986, false, false, clientCert, clientKey, nil, 0, 0)
 	client, err := winrm.NewClient(endpoint, "Administrator", ""
 	if err != nil {
 		panic(err)

--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func (r Requester) Transport(endpoint *Endpoint) error {
 }
 
 func (s *WinRMSuite) TestNewClient(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 
 	c.Assert(err, IsNil)
@@ -55,7 +55,7 @@ func (s *WinRMSuite) TestNewClient(c *C) {
 
 func (s *WinRMSuite) TestClientCreateShell(c *C) {
 
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 	r := Requester{}
@@ -74,7 +74,7 @@ func (s *WinRMSuite) TestRun(c *C) {
 	c.Assert(err, IsNil)
 	defer ts.Close()
 
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -90,7 +90,7 @@ func (s *WinRMSuite) TestRunWithString(c *C) {
 	ts, host, port, err := runWinRMFakeServer(c, "this is the input")
 	c.Assert(err, IsNil)
 	defer ts.Close()
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -106,7 +106,7 @@ func (s *WinRMSuite) TestRunWithInput(c *C) {
 	c.Assert(err, IsNil)
 	defer ts.Close()
 
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -210,7 +210,7 @@ func (s *WinRMSuite) TestReplaceTransportWithDecorator(c *C) {
 		return &ClientAuthRequest{}
 	}
 
-	endpoint := NewEndpoint("localhost", 5986, false, false, nil, []byte(cert), []byte(key), 0)
+	endpoint := NewEndpoint("localhost", 5986, false, false, nil, []byte(cert), []byte(key), 0, 0)
 	client, err := NewClientWithParameters(endpoint, "Administrator", "password", params)
 	c.Assert(err, IsNil)
 	_, ok := client.http.(*ClientAuthRequest)

--- a/command_test.go
+++ b/command_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *WinRMSuite) TestExecuteCommand(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -60,7 +60,7 @@ func (s *WinRMSuite) TestExecuteCommand(c *C) {
 }
 
 func (s *WinRMSuite) TestStdinCommand(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -97,7 +97,7 @@ func (s *WinRMSuite) TestStdinCommand(c *C) {
 }
 
 func (s *WinRMSuite) TestCommandExitCode(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -130,7 +130,7 @@ func (s *WinRMSuite) TestCommandExitCode(c *C) {
 }
 
 func (s *WinRMSuite) TestCloseCommandStopsFetch(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -209,7 +209,7 @@ func (s *WinRMSuite) TestConnectionTimeout(c *C) {
 		c.Error(err)
 	}
 
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 1*time.Second)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 1*time.Second,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -251,7 +251,7 @@ func (s *WinRMSuite) TestOperationTimeoutSupport(c *C) {
 		c.Error(err)
 	}
 
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -274,7 +274,7 @@ func (s *WinRMSuite) TestOperationTimeoutSupport(c *C) {
 
 func (s *WinRMSuite) TestEOFError(c *C) {
 	count := 0
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 	r := Requester{}

--- a/endpoint.go
+++ b/endpoint.go
@@ -24,6 +24,8 @@ type Endpoint struct {
 	CACert []byte // cert auth to intdetify the server cert
 	Key    []byte // public key for client auth connections
 	Cert   []byte // cert for client auth connections
+	//Connect Timeout for HTTP request
+	ConnectTimeout time.Duration
 	// duration timeout for the underling tcp conn(http/https base protocol)
 	// if the time exceeds the connection is cloded/timeouts
 	Timeout time.Duration
@@ -41,7 +43,7 @@ func (ep *Endpoint) url() string {
 }
 
 // NewEndpoint returns new pointer to struct Endpoint, with a default 60s response header timeout
-func NewEndpoint(host string, port int, https bool, insecure bool, Cacert, cert, key []byte, timeout time.Duration) *Endpoint {
+func NewEndpoint(host string, port int, https bool, insecure bool, Cacert, cert, key []byte, timeout time.Duration, connectTimeout time.Duration) *Endpoint {
 	endpoint := &Endpoint{
 		Host:     host,
 		Port:     port,
@@ -57,6 +59,13 @@ func NewEndpoint(host string, port int, https bool, insecure bool, Cacert, cert,
 	} else {
 		// assign default 60sec timeout
 		endpoint.Timeout = 60 * time.Second
+	}
+	// if the timeout was set
+	if connectTimeout != 0 {
+		endpoint.ConnectTimeout = connectTimeout
+	} else {
+		// assign default 60sec timeout
+		endpoint.ConnectTimeout = 30 * time.Second
 	}
 
 	return endpoint

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -17,11 +17,21 @@ func (s *WinRMSuite) TestEndpointUrlHttps(c *C) {
 }
 
 func (s *WinRMSuite) TestEndpointWithDefaultTimeout(c *C) {
-	endpoint := NewEndpoint("test", 5585, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("test", 5585, false, false, nil, nil, nil, 0,0)
 	c.Assert(endpoint.Timeout, Equals, 60*time.Second)
 }
 
 func (s *WinRMSuite) TestEndpointWithTimeout(c *C) {
-	endpoint := NewEndpoint("test", 5585, false, false, nil, nil, nil, 120*time.Second)
+	endpoint := NewEndpoint("test", 5585, false, false, nil, nil, nil, 120*time.Second,0)
 	c.Assert(endpoint.Timeout, Equals, 120*time.Second)
+}
+
+func (s *WinRMSuite) TestEndpointWithDefaultConnectTimeout(c *C) {
+	endpoint := NewEndpoint("test", 5585, false, false, nil, nil, nil, 0,0)
+	c.Assert(endpoint.ConnectTimeout, Equals, 30*time.Second)
+}
+
+func (s *WinRMSuite) TestEndpointWithConnectTimeout(c *C) {
+	endpoint := NewEndpoint("test", 5585, false, false, nil, nil, nil, 120*time.Second,120*time.Second)
+	c.Assert(endpoint.ConnectTimeout, Equals, 120*time.Second)
 }

--- a/http.go
+++ b/http.go
@@ -49,7 +49,7 @@ func (c *clientRequest) Transport(endpoint *Endpoint) error {
 			ServerName:         endpoint.TLSServerName,
 		},
 		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   endpoint.ConnectTimeout,
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		ResponseHeaderTimeout: endpoint.Timeout,

--- a/http_test.go
+++ b/http_test.go
@@ -45,7 +45,7 @@ func (s *WinRMSuite) TestHttpRequest(c *C) {
 	}))
 	c.Assert(err, IsNil)
 	defer ts.Close()
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "test", "test")
 	c.Assert(err, IsNil)
 	shell, err := client.CreateShell()

--- a/ntlm_test.go
+++ b/ntlm_test.go
@@ -13,7 +13,7 @@ func (s *WinRMSuite) TestHttpNTLMRequest(c *C) {
 	}))
 	c.Assert(err, IsNil)
 	defer ts.Close()
-	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0,0)
 
 	params := DefaultParameters
 	params.TransportDecorator = func() Transporter { return &ClientNTLM{} }

--- a/shell_test.go
+++ b/shell_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
@@ -29,7 +29,7 @@ func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
 }
 
 func (s *WinRMSuite) TestShellCloseResponse(c *C) {
-	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0,0)
 	client, err := NewClient(endpoint, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Problem:
When creating a WinRM session the TCP connect timeout is hard coded to be 30 seconds. This has been found to be problematic in certain scenarios when an endpoint exists but doesn't reply to the initial connect.

Solution:
Add a property to the endpoint in order to make the connect timeout configurable. Pass this through to the dialler at the point of connect. Ensure passing a 0 to the endpoint create function will default the connect timeout to be 30 seconds as it was previously.

Testing:
New unit tests added to establish the default value is as expected and a non default value is populated.